### PR TITLE
Scaling of the computer epsilon to solve pyNN bug when using spike_generator

### DIFF
--- a/models/spike_generator.cpp
+++ b/models/spike_generator.cpp
@@ -145,8 +145,9 @@ nest::spike_generator::Parameters_::assert_valid_spike_time_and_insert_( double 
     // Since substraction of closeby floating point values is
     // not stable, we have to compare with a delta.
     double_t offset = t_spike.get_ms() - t;
-    if ( std::fabs( offset ) < std::numeric_limits< double >::epsilon() )
-    {               // if difference is smaller than epsilon
+    if ( std::fabs( offset ) < std::numeric_limits< double >::epsilon() * std::fabs( t_spike.get_ms() + t) * 2.0 ||
+	std::fabs(offset) < std::numeric_limits< double >::min())
+    {               // if difference is smaller than scaled epsilon
       offset = 0.0; // than it is actually 0.0
     }
     assert( offset >= 0.0 );


### PR DESCRIPTION
The following pyNN code produces an issue when running with NEST backend:

> > import pyNN.nest as sim
> > sim.setup(timestep=0.1)
> > exc_stim = sim.Population(1, sim.SpikeSourceArray, cellparams={'spike_times': [353538.4]})

By scaling the machine epsilon according to the magnitude of the values being used solve this issue. It is also recommended in the documentation of the epsilon function (http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon).
